### PR TITLE
Fixed SBOM, now on software_version_num.py

### DIFF
--- a/backend/controllers/sbom_controller.py
+++ b/backend/controllers/sbom_controller.py
@@ -12,5 +12,5 @@ def get_sbom_controller():
     if not software_name or not software_version:
         return jsonify({"error": "Missing required parameters"}), 400
 
-    sbom = sbom_service.get_sbom(software_name, software_version)
+    sbom = sbom_service.get_sbom()
     return jsonify(sbom)

--- a/backend/services/sbom_service.py
+++ b/backend/services/sbom_service.py
@@ -29,8 +29,8 @@ class SBOMService:
         print("Dependencies Query:", dependencies_query)
         dependencies_response = self.sparql_client.query(dependencies_query)
 
-        if not isinstance(dependencies_response, list):
-            return []
+        # if not isinstance(dependencies_response, list):
+        #     return []
         return [str(row['dependency']) for row in dependencies_response]
     
     def get_vulnerabilities(self, software_name, software_version):

--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,21 @@
+{
+    "software_name": "aws-sdk-cpp",
+    "software_version": "1.9.22",
+    "dependencies": [
+        "https://w3id.org/secure-chain/SoftwareVersion/threads#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/openssl#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/project#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/testing-resources#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/git#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/app#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/c#2",
+        "https://w3id.org/secure-chain/SoftwareVersion/aws#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/android#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/aws-cpp-sdk-petstore#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/%24%7Btarget%7D#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/cmake_android_ndk_toolchain#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/awssdk#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/deps#%2A",
+        "https://w3id.org/secure-chain/SoftwareVersion/aws-crt-cpp#e7c13cd8c49c3cf073da1840ad8a14032e6ec89a"
+    ]
+}


### PR DESCRIPTION
Only the software_version_num.py file works if we wanna get the sbom. So the sbom_json object is the sbom. 

Only get dependencies.